### PR TITLE
Run tests on CircleCI for all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,6 @@ jobs:
         working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
         steps:
           - checkout
-
-          - run: |
-              apk add git make
-
+          - run: apk add git make
           - run: go get -v -t -d ./...
           - run: go test -v ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,25 @@
-version: 2 # use CircleCI 2.0
-jobs: # basic units of work in a run
-  build: # runs not using Workflows must have a `build` job as entry point
-    docker: # run the steps with Docker
-      # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
       - image: golang:1.12-alpine
 
-    steps: # steps that comprise the `build` job
-      - checkout # check out source code to working directory
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
 
-      - restore_cache: # restores saved cache if no changes are detected since last run
-          keys:
-            - go-mod-v4-{{ checksum "go.sum" }}
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    steps:
+      - checkout
 
-      - run:
-          name: Run unit tests
-
-          # store the results of our tests in the $TEST_RESULTS directory
-          command: |
-              go test -count 1 -covermode set -failfast ./...
-
-      - save_cache:
-          key: go-mod-v4-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
-
-workflows:
-  version: 2
-  build-workflow:
-    jobs:
-      - build
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,11 @@
-# Golang CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
   build:
     docker:
-      # specify the version
       - image: golang:1.12-alpine
-
-        # Specify service dependencies here if necessary
-        # CircleCI maintains a library of pre-built images
-        # documented at https://circleci.com/docs/2.0/circleci-images/
-        # - image: circleci/postgres:9.4
-
-        #### TEMPLATE_NOTE: go expects specific checkout path representing url
-        #### expecting it in the form of
-        ####   /go/src/github.com/circleci/go-tool
-        ####   /go/src/bitbucket.org/circleci/go-tool
-        working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
-        steps:
-          - checkout
-          - run: apk add git make
-          - run: go get -v -t -d ./...
-          - run: go test -v ./...
+    working_directory: /go/src/github.com/icyflame/year-in-twitter
+    steps:
+      - checkout
+      - run: apk add git make
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,9 @@ version: 2
 jobs:
   build:
     docker:
-      - image: golang:1.12-alpine
+      - image: circleci/golang:1.12
     working_directory: /go/src/github.com/icyflame/year-in-twitter
     steps:
       - checkout
-      - run: apk add git gcc
       - run: go get -v -t -d ./...
       - run: go test -v ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2 # use CircleCI 2.0
+jobs: # basic units of work in a run
+  build: # runs not using Workflows must have a `build` job as entry point
+    docker: # run the steps with Docker
+      # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
+      - image: golang:1.12-alpine
+
+    steps: # steps that comprise the `build` job
+      - checkout # check out source code to working directory
+
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          keys:
+            - go-mod-v4-{{ checksum "go.sum" }}
+
+      - run:
+          name: Run unit tests
+
+          # store the results of our tests in the $TEST_RESULTS directory
+          command: |
+              go test -count 1 -covermode set -failfast ./...
+
+      - save_cache:
+          key: go-mod-v4-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+
+workflows:
+  version: 2
+  build-workflow:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,6 @@ jobs:
     working_directory: /go/src/github.com/icyflame/year-in-twitter
     steps:
       - checkout
-      - run: git clone git@github.com/icyflame/gospec.git
+      - run: git clone git@github.com:icyflame/gospec.git
       - run: go get -v -t -d ./...
       - run: ./gospec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,5 @@ jobs:
           curl -s https://raw.githubusercontent.com/icyflame/gospec/master/gospec > gospec
           chmod +x gospec
       - run: go get -v -t -d ./...
-      - run: ./gospec
+      # Run tests, don't use colors, print the list of passing tests
+      - run: ./gospec -C -S

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ jobs:
     working_directory: /go/src/github.com/icyflame/year-in-twitter
     steps:
       - checkout
-      - run: git clone git@github.com:icyflame/gospec.git
+      - run: |
+          curl -s https://raw.githubusercontent.com/icyflame/gospec/master/gospec > gospec
+          chmod +x gospec
       - run: go get -v -t -d ./...
       - run: ./gospec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,5 +6,6 @@ jobs:
     working_directory: /go/src/github.com/icyflame/year-in-twitter
     steps:
       - checkout
+      - run: git clone git@github.com/icyflame/gospec.git
       - run: go get -v -t -d ./...
-      - run: go test -v ./...
+      - run: ./gospec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,18 +8,21 @@ jobs:
       # specify the version
       - image: golang:1.12-alpine
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
+        # Specify service dependencies here if necessary
+        # CircleCI maintains a library of pre-built images
+        # documented at https://circleci.com/docs/2.0/circleci-images/
+        # - image: circleci/postgres:9.4
 
-    #### TEMPLATE_NOTE: go expects specific checkout path representing url
-    #### expecting it in the form of
-    ####   /go/src/github.com/circleci/go-tool
-    ####   /go/src/bitbucket.org/circleci/go-tool
-    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
-    steps:
-      - checkout
+        #### TEMPLATE_NOTE: go expects specific checkout path representing url
+        #### expecting it in the form of
+        ####   /go/src/github.com/circleci/go-tool
+        ####   /go/src/bitbucket.org/circleci/go-tool
+        working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+        steps:
+          - checkout
 
-      - run: go get -v -t -d ./...
-      - run: go test -v ./...
+          - run: |
+              apk add git make
+
+          - run: go get -v -t -d ./...
+          - run: go test -v ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,6 @@ jobs:
     working_directory: /go/src/github.com/icyflame/year-in-twitter
     steps:
       - checkout
-      - run: apk add git make
+      - run: apk add git gcc
       - run: go get -v -t -d ./...
       - run: go test -v ./...

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
 [*]
 indent_style=space
 indent_size=4
+
+[*.yml]
+indent_style=space
+indent_size=2


### PR DESCRIPTION
## Summary

This PR adds the circle CI configuration. Internally, the configuration uses github.com/icyflame/gospec with no colors and the summary option set (i.e gospec will print the list of passing tests as well)